### PR TITLE
Fix: testui now shows raid frames when not in a raid

### DIFF
--- a/PTUnitFrameGroup.lua
+++ b/PTUnitFrameGroup.lua
@@ -52,7 +52,8 @@ function PTUnitFrameGroup:New(name, environment, units, petGroup, profile, sortB
 end
 
 function PTUnitFrameGroup:EvaluateShown()
-    if self:CanShowInEnvironment(Puppeteer.CurrentlyInRaid and "raid" or "party") and self:ShowCondition() then
+    local environment = Puppeteer.CurrentlyInRaid and "raid" or "party"
+    if (Puppeteer.TestUI or self:CanShowInEnvironment(environment)) and self:ShowCondition() then
         self:Show()
         self:UpdateUIPositions()
     else
@@ -65,7 +66,8 @@ function PTUnitFrameGroup:ShowCondition()
         return false
     end
 
-    if PTOptions.HideWhileSolo and (GetNumPartyMembers() == 0 and GetNumRaidMembers() == 0) then
+    if not Puppeteer.TestUI and PTOptions.HideWhileSolo
+            and (GetNumPartyMembers() == 0 and GetNumRaidMembers() == 0) then
         return false
     end
 


### PR DESCRIPTION
## Problem

`/pt testui` was meant to preview the whole UI with fake players, including a full fake raid — the fake-fill logic in `PTUnitFrameGroup:GetSortedUIs` already pads raid groups up to 40 when `Puppeteer.TestUI` is set. But when you run `/pt testui` while solo or in a party, no raid frames ever appear.

The cause is the environment gate in `PTUnitFrameGroup:EvaluateShown`:

```lua
if self:CanShowInEnvironment(Puppeteer.CurrentlyInRaid and "raid" or "party") and self:ShowCondition() then
```

`CurrentlyInRaid` is only set by `CheckGroup` when `GetNumRaidMembers() > 0`, and `TestUI` doesn't affect it. So while not actually in a raid, `"party"` is passed and the Raid / Raid Pets groups (environment `"raid"`) fail `CanShowInEnvironment` and stay hidden. The fake-fill branch is therefore never reached.

## Fix

In test mode, bypass the environment gate so all groups (Party, Pets, Raid, Raid Pets) show at once, and don't let `HideWhileSolo` hide the preview (testui is usually run solo):

- `EvaluateShown`: `Puppeteer.TestUI or self:CanShowInEnvironment(environment)`
- `ShowCondition`: skip the `HideWhileSolo` early-return when `Puppeteer.TestUI` is on

When TestUI is turned off, behavior is unchanged.

## Testing

- Solo, `/pt testui` → Party, Pets, and a full fake Raid (up to 40) + Raid Pets all appear.
- `SplitRaidIntoGroups` on → 8 subgroups of 5; off → single column.
- With `HideWhileSolo` enabled, testui still shows frames.
- Toggling testui off restores the previous solo/party-only behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)