### PR TITLE
Add option for vanilla (1.12.1) Shaman class color

### DIFF
--- a/PuppeteerSettings.lua
+++ b/PuppeteerSettings.lua
@@ -154,6 +154,7 @@ function SetDefaults()
             ["Hidden"] = false,
             ["HideWhileSolo"] = false,
             ["OutOfRangeArrow"] = true,
+            ["VanillaClassColors"] = false,
             ["ChosenProfiles"] = {
                 ["Party"] = PTProfileManager.DEFAULT_PROFILE_NAME,
                 ["Pets"] = PTProfileManager.DEFAULT_PROFILE_NAME,

--- a/gui/Settings.lua
+++ b/gui/Settings.lua
@@ -516,8 +516,16 @@ function CreateTab_Options_Other(panel)
     factory:checkbox("Show Heal Predictions", {"See predictions on incoming healing", "Improved predictions if using SuperWoW"},
         "UseHealPredictions", function() Puppeteer.UpdateAllIncomingHealing() end)
 
-    factory:checkbox("Out of Range Arrow", {"See an arrow when hovering over an out of range player"}, 
+    factory:checkbox("Out of Range Arrow", {"See an arrow when hovering over an out of range player"},
         "OutOfRangeArrow", function() Puppeteer.SetOutOfRangeArrowEnabled(PTOptions.OutOfRangeArrow) end)
+
+    factory:checkbox("Vanilla Shaman Color", {"Use the 1.12.1 class color for Shaman (pink, same as Paladin)",
+            "Disable for the blue Shaman color used in later expansions"}, "VanillaClassColors",
+            function()
+                for _, ui in ipairs(Puppeteer.AllUnitFrames) do
+                    ui:UpdateHealth()
+                end
+            end)
 
     factory:checkbox("(TWoW) LFT Auto Role", {"Automatically assign roles when joining LFT groups", 
             "This functionality was tested for 1.18.0 and may break in future updates"}, "LFTAutoRole",

--- a/libs/Util.lua
+++ b/libs/Util.lua
@@ -1136,8 +1136,17 @@ local classColors = {
     ["WARLOCK"] = {0.58, 0.51, 0.79},
     ["WARRIOR"] = {0.78, 0.61, 0.43}
 }
+-- 1.12.1: Shaman uses Paladin's color (pink); the blue Shaman color only exists in TBC+
+local vanillaClassColors = {
+    ["SHAMAN"] = {0.96, 0.55, 0.73},
+}
 function GetClassColor(class, asArray)
-    local color = classColors[class]
+    local color
+    if PTOptions and PTOptions.VanillaClassColors and vanillaClassColors[class] then
+        color = vanillaClassColors[class]
+    else
+        color = classColors[class]
+    end
     if not color then -- Unknown class
         color = {0.7, 0.7, 0.7}
     end


### PR DESCRIPTION
## Summary

The addon's class color table (`libs/Util.lua`) uses the TBC+ blue for Shaman (`{0.14, 0.35, 1.0}`), but in **1.12.1 the Shaman shares the Paladin's pink** (`{0.96, 0.55, 0.73}`) — the vanilla client's `RAID_CLASS_COLORS` used the same color for both (Shaman was Horde-only, Paladin Alliance-only, so they never shared a group). The distinct blue Shaman color was introduced in TBC.

This adds an account option **"Vanilla Shaman Color"** so players on a 1.12.1 client can use the period-correct color.

## Changes

- `libs/Util.lua` — `GetClassColor` returns the vanilla pink for Shaman when `PTOptions.VanillaClassColors` is set; otherwise unchanged.
- `PuppeteerSettings.lua` — new default `VanillaClassColors = false` (backfilled by `ApplyDefaults`, no options-version bump; keeps current behavior for existing users).
- `gui/Settings.lua` — checkbox in the Options tab. Its callback re-colors all health bars immediately (no `/reload` needed).

Only affects units whose health bar color mode is set to `Class`. Paladin and all other classes are unchanged.

## Testing

- Set a profile's Health Bar Color to `Class`, `/reload`, `/pt testui` while solo.
- Toggle "Vanilla Shaman Color": fake Shamans switch between blue (off) and pink (on) live; Paladins stay pink; other classes unchanged.
- No Lua errors with `/console scriptErrors 1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)